### PR TITLE
Add check to ensure event date in future

### DIFF
--- a/scripts/socialBot.coffee
+++ b/scripts/socialBot.coffee
@@ -288,6 +288,10 @@ listUsers = (res) ->
 addEvent = (res) ->
   eventName = res.match[1].trim()
   eventDate = chrono.parseDate(res.match[2].trim())
+
+  if eventDate < new Date()
+    eventDate.setDate(eventDate.getDate() + 7)
+
   eventLocation = res.match[3].trim()
   currentEvents = getFromRedis(res.robot.brain, 'events')
   user = getUsername(res)

--- a/scripts/socialBot.coffee
+++ b/scripts/socialBot.coffee
@@ -130,6 +130,24 @@ createPoll = (res, eventName, eventDateOptions) ->
 getDate = (dateString) ->
   return new Date(dateString)
 
+getFutureDate = (rawDate) ->
+  """
+  Return a date object from the rawDate which ensures
+  the event is not on a day in the past.
+  """
+  dateObject = chrono.parseDate(rawDate)
+
+  clonedDate = new Date(dateObject.getTime())
+  clonedDate.setHours(0,0,0,0)
+
+  currentDate = new Date()
+  currentDate.setHours(0,0,0,0)
+
+  if clonedDate < currentDate
+    dateObject.setDate(dateObject.getDate() + 7)
+
+  return dateObject
+
 getDateReadable = (dateString) ->
   if dateString is undefined
     return 'Undecided date and time'
@@ -287,10 +305,7 @@ listUsers = (res) ->
 
 addEvent = (res) ->
   eventName = res.match[1].trim()
-  eventDate = chrono.parseDate(res.match[2].trim())
-
-  if eventDate < new Date()
-    eventDate.setDate(eventDate.getDate() + 7)
+  eventDate = getFutureDate(res.match[2].trim())
 
   eventLocation = res.match[3].trim()
   currentEvents = getFromRedis(res.robot.brain, 'events')
@@ -429,7 +444,7 @@ forceRemind = (res) ->
 editRSVP = (res) ->
   eventName = res.match[2].trim()
   user = getUsername(res)
-  newDeadline = chrono.parseDate(res.match[3].trim())
+  newDeadline = getFutureDate(res.match[3].trim())
   selectedEvent = getEvent(eventName, res.robot.brain)
 
   if !selectedEvent
@@ -496,7 +511,7 @@ getEventDetails = (res) ->
 
 editEventTime = (res) ->
   eventName = res.match[1].trim()
-  eventDate = chrono.parseDate(res.match[2].trim())
+  eventDate = getFutureDate(res.match[2].trim())
   selectedEvent = getEvent(eventName, res.robot.brain)
   poll = getPoll(eventName, res.robot.brain)
   user = getUsername(res)


### PR DESCRIPTION
If the date of the new event is in the past, we add 7 days.

Chrono sometimes parses dates to be dates in the past.  
While this makes sense in general, this doesn't make sense in the
context of creating events. 

The approach here is to simply add a week to the date returned by chrono
in the case where the date returned has past.  This seemed like the easiest way
but I'm wondering if it could cause further bugs.

Another approach could be to ask the user of SocialBot to be more specific? 

Thoughts? 