### PR TITLE
Add calendar links

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "lmontopo@gmail.com",
   "description": "Helps organize social events! ",
   "dependencies": {
+    "@slack/client": "^4.3.1",
     "chrono-node": "^1.3.5",
     "coffee-script": "^1.12.7",
     "coffeescript": "^1.12.7",
@@ -15,13 +16,13 @@
     "hubot-help": "^0.2.2",
     "hubot-heroku-keepalive": "^1.0.3",
     "hubot-lets-chat": "0.0.7",
-    "hubot-slack": "",
     "hubot-maps": "0.0.3",
     "hubot-pugme": "^0.1.1",
     "hubot-redis-brain": "0.0.4",
     "hubot-rules": "^0.1.2",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.1",
+    "hubot-slack": "",
     "node-schedule": "^1.2.5"
   },
   "engines": {

--- a/scripts/socialBot.coffee
+++ b/scripts/socialBot.coffee
@@ -71,6 +71,39 @@ getFromRedis = (brain, key) ->
 
   return brain.get(key)
 
+getICSDate = (dateString) ->
+  iso_date = dateString.replace /[-:]/g, ""
+
+  return iso_date.split('.')[0]
+
+icsFormat = (res) ->
+
+  eventName = res.match[1].trim()
+  {
+    name,
+    description,
+    location,
+    date
+  } = getEvent(eventName, res.robot.brain)
+
+  ics_fields = [
+    # Global calendar fields
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    # Calendar event fields
+    "BEGIN:VEVENT",
+    "LOCATION:#{location}",
+    "DESCRIPTION:#{description}",
+    "SUMMARY:#{name}",
+    "DTSTART:#{getICSDate(date)}",
+    "END:VEVENT",
+    # End of calendar event fields
+    "END:VCALENDAR"
+    # End of global calendar fields
+  ]
+
+  res.send ics_fields.join('\n')
+
 createEvent = (res, eventName, eventLocation, eventDate = undefined) ->
   """
   Perform checks to ensure event makes sense, and if so,
@@ -608,6 +641,7 @@ eventAttendance = (res) ->
 
 module.exports = (robot) ->
 
+  robot.respond /test ([\w: ]+)/i, icsFormat
   robot.respond /list/i, listEvents
   robot.respond /vote ([\w: ]+) for ([\w ]+)$/i, vote
   robot.respond /organize ([\w ]+) with poll at ([\w ]+) for: ([\w:, ]+)$/i, addEventWithPoll

--- a/scripts/socialBot.coffee
+++ b/scripts/socialBot.coffee
@@ -87,7 +87,10 @@ getICSDate = (dateObject) ->
   return iso_date.split('.')[0]
 
 icsFileContent = (res, eventName) ->
-
+  """
+  Get the event given eventName and parse out the event
+  details into a valid .ics file format.
+  """
   {
     name,
     description,
@@ -95,8 +98,6 @@ icsFileContent = (res, eventName) ->
     date,
     #dateEnd, Uncomment when implemented in issue #26
   } = getEvent(eventName, res.robot.brain)
-
-
 
   ics_fields = [
     "BEGIN:VCALENDAR",


### PR DESCRIPTION
fixes issue #21 

From event data (name, description, date), create a Buffer that follows the format of .ics files. Then use the Slack API to upload the .ics file.

I chose the .ics file format because it is compatible with Google Calendar and Apple's Calendar and generally has good support. However, Slack doesn't naturally support the .ics file type so when uploading an .ics file via the API the file type shows as 'Binary' which makes it seem like a sketchier file type. Google Calendar supports .csv but Apple's Calendar doesn't so that seemed like a bad alternative.

To test this in Slack, run `HUBOT_SLACK_TOKEN=xxx ./bin/hubot --adapter slack`. I created a `#socialbottest` room for testing.

**TODO:** 
- [ ] Get the file upload to work (~~Maybe Socialbot doesn't have permission to upload files?~~ Actually I don't think this is true because I was able to uplaod files as SocialBot using an actual API request `curl -F file=@test.ics filetype="ics" -F channels=#socialbottest -F token=xxx https://slack.com/api/files.upload`)
- [ ] Create a helper method for file uploads so that we can reuse the code and send the files in other responses (get event details, event reminders)